### PR TITLE
Updated SHT3X so it can support different and configurable I2C busses through TwoWire

### DIFF
--- a/src/SHT3X.cpp
+++ b/src/SHT3X.cpp
@@ -1,70 +1,45 @@
 #include "SHT3X.h"
 
-/* Motor()
-
-*/
-SHT3X::SHT3X(uint8_t address, uint8_t deviceType) {
-    if (deviceType == 0)
-        Wire.begin();
-    else if (deviceType == 1)
-        Wire.begin(0, 26);
-    else if (deviceType == 2)
-        Wire.begin(2, 1);
-    _address = address;
+bool SHT3X::init(uint8_t slave_addr_in, TwoWire* wire_in)
+{
+  _wire = wire_in;
+  _address=slave_addr_in;
+  return true;
 }
 
-// /*! @Detecting whether a device is a Unit or a Hat
-//     @return Return 0 for Unit, 1 for Hat */
-// bool SHT3X::detectDevice() {
-//     unsigned int data[6];
-//     Wire.begin();
-//     Wire.beginTransmission(_address);
-//     Wire.write(0x2C);
-//     Wire.write(0x06);
-//     // Stop I2C transmission
-//     Wire.endTransmission();
-//     Wire.requestFrom(_address, (uint8_t)1);
-//     for (int i = 0; i < 6; i++) {
-//         data[i] = Wire.read();
-//         Serial.printf("data%d:%d ", i, data[i]);
-//     };
-//     if (data[1] == -1) {
-//         Wire.begin(0, 26);
-//         return 1;
-//     }
-//     return 0;
-// }
+byte SHT3X::get()
+{
+  unsigned int data[6];
 
-byte SHT3X::get() {
-    unsigned int data[6];
+  // Start I2C Transmission
+  _wire->beginTransmission(_address);
+  // Send measurement command
+  _wire->write(0x2C);
+  _wire->write(0x06);
+  // Stop I2C transmission
+  if (_wire->endTransmission()!=0) 
+    return 1;  
 
-    // Start I2C Transmission
-    Wire.beginTransmission(_address);
-    // Send measurement command
-    Wire.write(0x2C);
-    Wire.write(0x06);
-    // Stop I2C transmission
-    if (Wire.endTransmission() != 0) return 1;
+  delay(200);
 
-    delay(200);
+  // Request 6 bytes of data
+  _wire->requestFrom(_address, (uint8_t) 6);
 
-    // Request 6 bytes of data
-    Wire.requestFrom(_address, (uint8_t)6);
+  // Read 6 bytes of data
+  // cTemp msb, cTemp lsb, cTemp crc, humidity msb, humidity lsb, humidity crc
+  for (int i=0;i<6;i++) {
+    data[i]=_wire->read();
+  };
+  
+  delay(50);
+  
+  if (_wire->available()!=0) 
+    return 2;
 
-    // Read 6 bytes of data
-    // cTemp msb, cTemp lsb, cTemp crc, humidity msb, humidity lsb, humidity crc
-    for (int i = 0; i < 6; i++) {
-        data[i] = Wire.read();
-    };
+  // Convert the data
+  cTemp = ((((data[0] * 256.0) + data[1]) * 175) / 65535.0) - 45;
+  fTemp = (cTemp * 1.8) + 32;
+  humidity = ((((data[3] * 256.0) + data[4]) * 100) / 65535.0);
 
-    delay(50);
-
-    if (Wire.available() != 0) return 2;
-
-    // Convert the data
-    cTemp    = ((((data[0] * 256.0) + data[1]) * 175) / 65535.0) - 45;
-    fTemp    = (cTemp * 1.8) + 32;
-    humidity = ((((data[3] * 256.0) + data[4]) * 100) / 65535.0);
-
-    return 0;
+  return 0;
 }

--- a/src/SHT3X.h
+++ b/src/SHT3X.h
@@ -1,25 +1,26 @@
-#ifndef _SHT3X_H_
-#define _SHT3X_H_
+#ifndef __SHT3X_H
+#define __HT3X_H
+
 
 #if ARDUINO >= 100
-#include "Arduino.h"
+ #include "Arduino.h"
 #else
-#include "WProgram.h"
+ #include "WProgram.h"
 #endif
 
 #include "Wire.h"
 
-class SHT3X {
-   public:
-    SHT3X(uint8_t address = 0x44, uint8_t deviceType = 0);
-    byte get(void);
-    bool detectDevice();
-    float cTemp    = 0;
-    float fTemp    = 0;
-    float humidity = 0;
+class SHT3X{
+public:
+  bool init(uint8_t slave_addr_in=0x44, TwoWire* wire_in = &Wire);
+  byte get(void);
+  float cTemp=0;
+  float fTemp=0;
+  float humidity=0;
 
-   private:
-    uint8_t _address;
+private:
+  uint8_t _address;
+  TwoWire* _wire;
 };
 
 #endif


### PR DESCRIPTION
Updated SHT3X so it can support different and configurable I2C busses through TwoWire, inline to how QMP6988 is implemented.

This modificaton allows the transparent use of this library for complex projects like weather stations that use multiple I2C busses at the same time. An example code would be:

```
TwoWire I2C_SGP30 = TwoWire(0);
TwoWire I2C_SHT30 = TwoWire(1);

SHT30 sht30;
QMP6988 qmp6988;
Adafruit_SGP30 sgp30;

void setup() {
    
    if (!I2C_SGP30.begin(32, 33, (uint32_t) 100000)) {
      Serial.println(F("[ERR] SGP30 bus init failed "));
    }
    if (!I2C_SHT30.begin(25, 26, (uint32_t) 100000)) {
      Serial.println(F("[ERR] SHT30 bus init failed "));
    }

    if (!qmp6988.init(0x70, &I2C_SHT30)) {
      Serial.println(F("[ERR] No qmp6988 Detected"));
    }else{
      Serial.println(F("[OK] qmp6988 Initialized"));
    }

    if (!sht30.init(0x44, &I2C_SHT30)) {
      Serial.println(F("[ERR] No SHT30 Detected"));
    }else{
      Serial.println(F("[OK] SHT30 Initialized"));
    }

    if (!sgp30.begin(&I2C_SGP30)) {
      Serial.println(F("[ERR] No SGP30 Detected"));
    }else{
      Serial.println(F("[OK] SGP30 Initialized"));
    }
}
```