### PR TITLE
Fixes calculation in getTemperatureOffset

### DIFF
--- a/src/SCD4X.cpp
+++ b/src/SCD4X.cpp
@@ -300,7 +300,7 @@ bool SCD4X::getTemperatureOffset(float *offset) {
     uint16_t offsetWord = 0;  // offset will be zero if readRegister fails
     bool success =
         readRegister(SCD4x_COMMAND_GET_TEMPERATURE_OFFSET, &offsetWord, 1);
-    *offset = ((float)offsetWord) * 175.0 / 65535.0;
+    *offset = ((float)offsetWord) * 175.0 / 65536.0;
     return (success);
 }
 


### PR DESCRIPTION
![スクリーンショット 2024-05-07 12 43 25](https://github.com/m5stack/M5Unit-ENV/assets/26270227/0d971fb2-83ad-428f-a7ed-738e447982e3)

Conversion from uint16_t to float seems wrong.