### PR TITLE
Removed unnecessary println in SHT4X

### DIFF
--- a/src/SHT4X.cpp
+++ b/src/SHT4X.cpp
@@ -61,7 +61,6 @@ bool SHT4X::update() {
 
     _wire->requestFrom(_addr, (uint8_t)6);
 
-    Serial.println();
     for (uint16_t i = 0; i < 6; i++) {
         readbuffer[i] = _wire->read();
     }


### PR DESCRIPTION
There is an empty new line printed to Serial on each SH40 update, that's quite bothersome. I don't suppose it's there intentionally. Can we delete it?