### PR TITLE
Support latest Bosch libraries and M5UnitUnified 0.1.x

### DIFF
--- a/examples/UnitUnified/UnitCO2/PlotToSerial/main/PlotToSerial.cpp
+++ b/examples/UnitUnified/UnitCO2/PlotToSerial/main/PlotToSerial.cpp
@@ -80,7 +80,7 @@ void setup()
         if (!ret) {
             lcd.clear(TFT_RED);
             while (true) {
-                m5::utility::delay(1000);
+                m5::utility::delay(10000);
             }
         }
     }

--- a/examples/UnitUnified/UnitCO2L/PlotToSerial/main/PlotToSerial.cpp
+++ b/examples/UnitUnified/UnitCO2L/PlotToSerial/main/PlotToSerial.cpp
@@ -14,7 +14,6 @@
 namespace {
 auto& lcd = M5.Display;
 m5::unit::UnitUnified Units;
-// m5::unit::UnitCO2 unit;
 m5::unit::UnitCO2L unit;
 
 }  // namespace

--- a/examples/UnitUnified/UnitENVIII/PlotToSerial/main/PlotToSerial.cpp
+++ b/examples/UnitUnified/UnitENVIII/PlotToSerial/main/PlotToSerial.cpp
@@ -77,6 +77,7 @@ void setup()
     }
 #else
 #pragma message "Using Wire"
+    Wire.end();
     Wire.begin(pin_num_sda, pin_num_scl, 400000U);
 
     if (!Units.add(unitENV3, Wire) || !Units.begin()) {
@@ -134,19 +135,19 @@ void loop()
     if (M5.BtnA.wasClicked()) {
         m5::unit::sht30::Data ds{};
         if (sht30.measureSingleshot(ds)) {
-            M5_LOGI("\n>SHT30Temp:%2.2f\n>Humidity:%2.2f", ds.temperature(), ds.humidity());
+            M5.Log.printf(">SHT30Temp:%2.2f\n>Humidity:%2.2f\n", ds.temperature(), ds.humidity());
         }
         m5::unit::qmp6988::Data dq{};
         if (qmp6988.measureSingleshot(dq)) {
-            M5_LOGI("\n>QMP6988Temp:%2.2f\n>Pressure:%.2f", dq.temperature(), dq.pressure());
+            M5.Log.printf(">QMP6988Temp:%2.2f\n>Pressure:%.2f\n", dq.temperature(), dq.pressure() * 0.01f);
         }
     }
 #else
     if (sht30.updated()) {
-        M5_LOGI("\n>SHT30Temp:%2.2f\n>Humidity:%2.2f", sht30.temperature(), sht30.humidity());
+        M5.Log.printf(">SHT30Temp:%2.2f\n>Humidity:%2.2f\n", sht30.temperature(), sht30.humidity());
     }
     if (qmp6988.updated()) {
-        M5_LOGI("\n>QMP6988Temp:%2.2f\n>Pressure:%.2f", qmp6988.temperature(), qmp6988.pressure());
+        M5.Log.printf(">QMP6988Temp:%2.2f\n>Pressure:%.2f\n", qmp6988.temperature(), qmp6988.pressure() * 0.01f);
     }
 #endif
 }

--- a/examples/UnitUnified/UnitENVIV/PlotToSerial/main/PlotToSerial.cpp
+++ b/examples/UnitUnified/UnitENVIV/PlotToSerial/main/PlotToSerial.cpp
@@ -60,6 +60,7 @@ void setup()
     }
 
 #if defined(USING_ENV4)
+    Wire.end();
     Wire.begin(pin_num_sda, pin_num_scl, 400000U);
 
     if (!Units.add(unitENV4, Wire) || !Units.begin()) {
@@ -70,6 +71,7 @@ void setup()
         }
     }
 #else
+    Wire.end();
     Wire.begin(pin_num_sda, pin_num_scl, 400000U);
     if (!Units.add(unitSHT40, Wire) || !Units.add(unitBMP280, Wire) || !Units.begin()) {
         M5_LOGE("Failed to begin");
@@ -91,17 +93,17 @@ void loop()
     Units.update();
 
     if (sht40.updated()) {
-        M5_LOGI(
-            "\n>SHT40Temp:%.4f\n"
-            ">Humidity:%.4f",
+        M5.Log.printf(
+            ">SHT40Temp:%.4f\n"
+            ">Humidity:%.4f\n",
             sht40.temperature(), sht40.humidity());
     }
     if (bmp280.updated()) {
         auto p = bmp280.pressure();
-        M5_LOGI(
-            "\n>BMP280Temp:%.4f\n"
+        M5.Log.printf(
+            ">BMP280Temp:%.4f\n"
             ">Pressure:%.4f\n"
-            ">Altitude:%.4f",
+            ">Altitude:%.4f\n",
             bmp280.temperature(), p * 0.01f /* To hPa */, calculate_altitude(p));
     }
 }

--- a/examples/UnitUnified/UnitENVPro/PlotToSerial/main/PlotToSerial.cpp
+++ b/examples/UnitUnified/UnitENVPro/PlotToSerial/main/PlotToSerial.cpp
@@ -18,13 +18,12 @@ m5::unit::UnitENVPro unit;
 
 void setup()
 {
-    m5::utility::delay(2000);
-
     M5.begin();
 
     auto pin_num_sda = M5.getPin(m5::pin_name_t::port_a_sda);
     auto pin_num_scl = M5.getPin(m5::pin_name_t::port_a_scl);
     M5_LOGI("getPin: SDA:%u SCL:%u", pin_num_sda, pin_num_scl);
+    Wire.end();
     Wire.begin(pin_num_sda, pin_num_scl, 400 * 1000U);
 
     if (!Units.add(unit, Wire) || !Units.begin()) {
@@ -46,11 +45,11 @@ void loop()
     Units.update();
     if (unit.updated()) {
 #if defined(UNIT_BME688_USING_BSEC2)
-        M5_LOGI("\n>IAQ:%.2f\n>Temperature:%.2f\n>Pressure:%.2f\n>Humidity:%.2f\n>GAS:%.2f", unit.iaq(),
-                unit.temperature(), unit.pressure(), unit.humidity(), unit.gas());
+        M5.Log.printf(">IAQ:%.2f\n>Temperature:%.2f\n>Pressure:%.2f\n>Humidity:%.2f\n>GAS:%.2f\n", unit.iaq(),
+                      unit.temperature(), unit.pressure(), unit.humidity(), unit.gas());
 #else
-        M5_LOGI("\n>Temperature:%.2f\n>Pressure:%.2f\n>Humidity:%.2f\n>GAS:%.2f", unit.temperature(), unit.pressure(),
-                unit.humidity(), unit.gas());
+        M5.Log.printf(">Temperature:%.2f\n>Pressure:%.2f\n>Humidity:%.2f\n>GAS:%.2f\n", unit.temperature(),
+                      unit.pressure(), unit.humidity(), unit.gas());
         m5::utility::delay(1000);
 #endif
     }

--- a/examples/UnitUnified/UnitTVOC/PlotToSerial/main/PlotToSerial.cpp
+++ b/examples/UnitUnified/UnitTVOC/PlotToSerial/main/PlotToSerial.cpp
@@ -25,6 +25,7 @@ void setup()
     auto pin_num_sda = M5.getPin(m5::pin_name_t::port_a_sda);
     auto pin_num_scl = M5.getPin(m5::pin_name_t::port_a_scl);
     M5_LOGI("getPin: SDA:%u SCL:%u", pin_num_sda, pin_num_scl);
+    Wire.end();
     Wire.begin(pin_num_sda, pin_num_scl, 400 * 1000U);
 
     if (!Units.add(unit, Wire) || !Units.begin()) {
@@ -50,6 +51,6 @@ void loop()
     // SGP30 measurement starts 15 seconds after begin.
     if (unit.updated()) {
         // Can be checked on serial plotters
-        M5_LOGI("\n>CO2eq:%u\n>TVOC:%u", unit.co2eq(), unit.tvoc());
+        M5.Log.printf("\n>CO2eq:%u\n>TVOC:%u", unit.co2eq(), unit.tvoc());
     }
 }

--- a/library.json
+++ b/library.json
@@ -10,12 +10,13 @@
         "type": "git",
         "url": "https://github.com/m5stack/M5Unit-ENV.git"
     },
-    "dependencies": {
-        "M5UnitUnified": "https://github.com/m5stack/M5UnitUnified.git",
-        "BME68x Sensor library": "https://github.com/boschsensortec/Bosch-BME68x-Library.git",
-        "bsec2": "https://github.com/boschsensortec/Bosch-BSEC2-Library"
+    "dependencies":
+    {
+	"m5stack/M5UnitUnified": ">=0.1.0",
+	"boschsensortec/BME68x Sensor library": ">=1.3.40408",
+	"boschsensortec/bsec2": ">=1.10.2610"
     },
-    "version": "1.2.1",
+    "version": "1.3.0",
     "frameworks": [
         "arduino"
     ],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=M5Unit-ENV
-version=1.2.1
+version=1.3.0
 author=M5Stack
 maintainer=M5Stack
 sentence=Library for M5Stack UNIT ENV

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,11 +12,11 @@ test_framework = googletest
 test_build_src = true
 lib_deps=m5stack/M5Unified
   m5stack/M5UnitUnified
-  https://github.com/boschsensortec/Bosch-BME68x-Library.git @ 1.2.40408
+  boschsensortec/BME68x Sensor library@>=1.3.40408
 
 ; --------------------------------
 [bsec2]
-lib_deps = https://github.com/boschsensortec/Bosch-BSEC2-Library.git @ 1.8.2610
+lib_deps = boschsensortec/bsec2@>=1.10.2610
 
 [m5base]
 monitor_speed = 115200

--- a/src/unit/unit_BME688.cpp
+++ b/src/unit/unit_BME688.cpp
@@ -127,7 +127,7 @@ float Data::get(const bsec_virtual_sensor_t vs) const
 //
 const char UnitBME688::name[] = "UnitBME688";
 const types::uid_t UnitBME688::uid{"UnitBME688"_mmh3};
-const types::attr_t UnitBME688::attr{};
+const types::attr_t UnitBME688::attr{attribute::AccessI2C};
 
 // I2C accessor
 int8_t UnitBME688::read_function(uint8_t reg_addr, uint8_t* reg_data, uint32_t length, void* intf_ptr)

--- a/src/unit/unit_BME688.hpp
+++ b/src/unit/unit_BME688.hpp
@@ -10,13 +10,6 @@
 #ifndef M5_UNIT_ENV_UNIT_BME688_HPP
 #define M5_UNIT_ENV_UNIT_BME688_HPP
 
-#if (defined(ESP_PLATFORM) && (!defined(CONFIG_IDF_TARGET_ESP32C6) &&                                      \
-                               (!defined(ARDUINO_M5Stack_NanoC6) && !defined(ARDUINO_M5STACK_NANOC6)))) || \
-    defined(DOXYGEN_PROCESS)
-#pragma message "Using BSEC2"
-#define UNIT_BME688_USING_BSEC2
-#endif
-
 #include <M5UnitComponent.hpp>
 #include <m5_utility/stl/extension.hpp>
 
@@ -26,7 +19,13 @@
 #include <bme68x/bme68x.h>
 #endif
 
-#if defined(UNIT_BME688_USING_BSEC2)
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+#pragma message "Not using bsec2"
+
+#else
+#pragma message "Using bsec2"
+#define UNIT_BME688_USING_BSEC2
+
 #if defined(ARDUINO)
 #include <bsec2.h>
 #else
@@ -34,6 +33,7 @@
 #endif
 
 #endif
+
 #include <memory>
 #include <limits>
 #include <initializer_list>

--- a/src/unit/unit_BMP280.cpp
+++ b/src/unit/unit_BMP280.cpp
@@ -240,7 +240,7 @@ float Data::pressure() const
 
 const char UnitBMP280::name[] = "UnitBMP280";
 const types::uid_t UnitBMP280::uid{"UnitBMP280"_mmh3};
-const types::attr_t UnitBMP280::attr{};
+const types::attr_t UnitBMP280::attr{attribute::AccessI2C};
 
 bool UnitBMP280::begin()
 {

--- a/src/unit/unit_ENV3.hpp
+++ b/src/unit/unit_ENV3.hpp
@@ -11,7 +11,6 @@
 #define M5_UNIT_ENV_UNIT_ENV3_HPP
 
 #include <M5UnitComponent.hpp>
-#include <array>
 #include "unit_SHT30.hpp"
 #include "unit_QMP6988.hpp"
 
@@ -42,7 +41,7 @@ public:
     }
 
 protected:
-    virtual Adapter* duplicate_adapter(const uint8_t ch) override;
+    virtual std::shared_ptr<Adapter> ensure_adapter(const uint8_t ch);
 
 private:
     bool _valid{};  // Did the constructor correctly add the child unit?

--- a/src/unit/unit_ENV4.cpp
+++ b/src/unit/unit_ENV4.cpp
@@ -14,10 +14,11 @@ namespace m5 {
 namespace unit {
 
 using namespace m5::utility::mmh3;
+using namespace m5::unit::types;
 
-const char UnitENV4::name[] = "UnitENVIV";
-const types::uid_t UnitENV4::uid{"UnitENVIV"_mmh3};
-const types::attr_t UnitENV4::attr{0};
+const char UnitENV4::name[] = "UnitENV4";
+const types::uid_t UnitENV4::uid{"UnitENV4"_mmh3};
+const types::attr_t UnitENV4::attr{attribute::AccessI2C};
 
 UnitENV4::UnitENV4(const uint8_t addr) : Component(addr)
 {
@@ -28,14 +29,19 @@ UnitENV4::UnitENV4(const uint8_t addr) : Component(addr)
     _valid = add(sht40, 0) && add(bmp280, 1);
 }
 
-Adapter* UnitENV4::duplicate_adapter(const uint8_t ch)
+std::shared_ptr<Adapter> UnitENV4::ensure_adapter(const uint8_t ch)
 {
-    if (ch >= 2) {
+    if (ch > 2) {
         M5_LIB_LOGE("Invalid channel %u", ch);
-        return nullptr;
+        return std::make_shared<Adapter>();  // Empty adapter
     }
-    auto unit = _children[ch];
-    return adapter()->duplicate(unit->address());
+    auto unit = child(ch);
+    if (!unit) {
+        M5_LIB_LOGE("Not exists unit %u", ch);
+        return std::make_shared<Adapter>();  // Empty adapter
+    }
+    auto ad = asAdapter<AdapterI2C>(Adapter::Type::I2C);
+    return ad ? std::shared_ptr<Adapter>(ad->duplicate(unit->address())) : std::make_shared<Adapter>();
 }
 
 }  // namespace unit

--- a/src/unit/unit_ENV4.hpp
+++ b/src/unit/unit_ENV4.hpp
@@ -42,7 +42,7 @@ public:
     }
 
 protected:
-    virtual Adapter* duplicate_adapter(const uint8_t ch) override;
+    virtual std::shared_ptr<Adapter> ensure_adapter(const uint8_t ch);
 
 private:
     bool _valid{};  // Did the constructor correctly add the child unit?

--- a/src/unit/unit_QMP6988.cpp
+++ b/src/unit/unit_QMP6988.cpp
@@ -210,7 +210,7 @@ float Data::pressure() const
 //
 const char UnitQMP6988::name[] = "UnitQMP6988";
 const types::uid_t UnitQMP6988::uid{"UnitQMP6988"_mmh3};
-const types::attr_t UnitQMP6988::attr{};
+const types::attr_t UnitQMP6988::attr{attribute::AccessI2C};
 
 types::elapsed_time_t calculatInterval(const Standby st, const Oversampling ost, const Oversampling osp, const Filter f)
 {

--- a/src/unit/unit_SCD40.cpp
+++ b/src/unit/unit_SCD40.cpp
@@ -73,7 +73,7 @@ float Data::humidity() const
 // class UnitSCD40
 const char UnitSCD40::name[] = "UnitSCD40";
 const types::uid_t UnitSCD40::uid{"UnitSCD40"_mmh3};
-const types::attr_t UnitSCD40::attr{0};
+const types::attr_t UnitSCD40::attr{attribute::AccessI2C};
 
 bool UnitSCD40::begin()
 {

--- a/src/unit/unit_SCD41.cpp
+++ b/src/unit/unit_SCD41.cpp
@@ -31,7 +31,7 @@ namespace unit {
 // class UnitSCD41
 const char UnitSCD41::name[] = "UnitSCD41";
 const types::uid_t UnitSCD41::uid{"UnitSCD41"_mmh3};
-const types::attr_t UnitSCD41::attr{};
+const types::attr_t UnitSCD41::attr{attribute::AccessI2C};
 
 bool UnitSCD41::is_valid_chip()
 {

--- a/src/unit/unit_SGP30.cpp
+++ b/src/unit/unit_SGP30.cpp
@@ -50,7 +50,7 @@ uint16_t Data::tvoc() const
 // class UnitSGP30
 const char UnitSGP30::name[] = "UnitSGP30";
 const types::uid_t UnitSGP30::uid{"UnitSGP30"_mmh3};
-const types::attr_t UnitSGP30::attr{};
+const types::attr_t UnitSGP30::attr{attribute::AccessI2C};
 
 bool UnitSGP30::begin()
 {

--- a/src/unit/unit_SHT30.cpp
+++ b/src/unit/unit_SHT30.cpp
@@ -87,7 +87,7 @@ float Data::humidity() const
 
 const char UnitSHT30::name[] = "UnitSHT30";
 const types::uid_t UnitSHT30::uid{"UnitSHT30"_mmh3};
-const types::attr_t UnitSHT30::attr{};
+const types::attr_t UnitSHT30::attr{attribute::AccessI2C};
 
 bool UnitSHT30::begin()
 {

--- a/src/unit/unit_SHT40.cpp
+++ b/src/unit/unit_SHT40.cpp
@@ -71,7 +71,7 @@ float Data::humidity() const
 
 const char UnitSHT40::name[] = "UnitSHT40";
 const types::uid_t UnitSHT40::uid{"UnitSHT40"_mmh3};
-const types::attr_t UnitSHT40::attr{};
+const types::attr_t UnitSHT40::attr{attribute::AccessI2C};
 
 bool UnitSHT40::begin()
 {


### PR DESCRIPTION
- Raise version 1.3.0
- Fixes  due to M5UnitUnified update (Support for 0.1.0 or later)
- Fixes  due to Bosch libraries update


### remarks
Git Hub Actions 

Build(arduino-m5stack)
error cause by M5GFX

It can be ignored.

```
/home/runner/Arduino/libraries/M5GFX/src/lgfx/v1/platforms/esp32/common.cpp:826:17: error: 'void lgfx::v1::i2c::i2c_periph_disable(int)' defined but not used [-Werror=unused-function]
     static void i2c_periph_disable(int i2c_num)
                 ^~~~~~~~~~~~~~~~~~
/home/runner/Arduino/libraries/M5GFX/src/lgfx/v1/platforms/esp32/common.cpp:820:17: error: 'void lgfx::v1::i2c::i2c_periph_enable(int)' defined but not used [-Werror=unused-function]
     static void i2c_periph_enable(int i2c_num)
                 ^~~~~~~~~~~~~~~~~
```